### PR TITLE
Return false when writeStream fails

### DIFF
--- a/src/FileStoreAdapter.php
+++ b/src/FileStoreAdapter.php
@@ -407,6 +407,11 @@ class FileStoreAdapter extends AbstractAdapter implements AdapterInterface
     public function writeStream($path, $resource, \League\Flysystem\Config $config)
     {
         $meta = $this->write($path, $resource, $config);
+        
+        if($meta === false) {
+            return false;
+        }
+        
         $meta['stream'] = $resource;
         return $meta;
     }


### PR DESCRIPTION
Fixes a bug where using writeStream expects a false return value when it fails, was actually returning a truthy object.

This impacts the storage manager functionality when using copy as it will return true for a copy even if the copy failed. Noticed when trying to copy a large file from stream to stream and had a low timeout set.
